### PR TITLE
Remove override specification

### DIFF
--- a/src/preprocessor/preprocessor.h
+++ b/src/preprocessor/preprocessor.h
@@ -209,7 +209,7 @@ protected:
     /* callback that is invoked when an #include (or #import) is encountered */
     virtual void InclusionDirective(SourceLocation, const Token &, StringRef, bool, CharSourceRange,
                                     const FileEntry *, StringRef, StringRef, const clang::Module *, 
-                                    SrcMgr::CharacteristicKind) override;
+                                    SrcMgr::CharacteristicKind);
 
 
 private:


### PR DESCRIPTION
IncludesProcessor::InclusionDirective was declared with an override specification. IncludesProcessor inherits from PPCallbacks, and it does not declare an InclusionDirective virtual function (in LLVM 6.0.1).

This change makes it so that the preprocessor tool actually compiles.

Closes #14; Closes #19 